### PR TITLE
Docs: updated manual1 and manual2 for clarity, examples, and typos

### DIFF
--- a/docs/manual/manual-1.org
+++ b/docs/manual/manual-1.org
@@ -5,7 +5,7 @@
 ** Installation
 *Note that ESBMTK 0.14.2.x requires python 3.12 or higher.*
 *** Conda
-ESBMTK is available via through the conda-forge channel https://conda-forge.org/
+ESBMTK is available via the conda-forge channel https://conda-forge.org/
 Assuming you install into a new virtual environment the following should install the ESBMTK framework
 #+BEGIN_SRC sh
 conda create --name foo python=3.12
@@ -42,7 +42,7 @@ and for the deep ocean,
 \]
 
 
-which is easily encoded as a Python function
+which is easily encoded as a Python function:
 #+BEGIN_SRC ipython
 def dCdt(t, C_0, V, F_w, thx):
     """ Calculate the change in concentration as
@@ -167,7 +167,7 @@ tau = Q_("100 years")
 tau * 12
 #+END_SRC
 
-Most ESBMTK classes accept quantities, strings that represent quantities as well as numerical values. Weathering and burial fluxes are often defined in =mol/year=, whereas ocean models use =kg/year=. ESBMTK provides a method (=set_flux()= )  that will automatically convert the input into the correct units. In this example, it is not necessary since the flux and the model both use =mol=. It is however good practice to rely on the automatic conversion. Note that it makes a difference for the mol to kilogram conversion whether one uses =M.P= or =M.PO4= as the reference species!
+Most ESBMTK classes accept quantities, strings that represent quantities, as well as numerical values. Weathering and burial fluxes are often defined in =mol/year=, whereas ocean models use =kg/year=. ESBMTK provides a method (=set_flux()= )  that will automatically convert the input into the correct units. In this example, it is not necessary since the flux and the model both use =mol=. It is however good practice to rely on the automatic conversion. Note that it makes a difference for the mol to kilogram conversion whether one uses =M.P= or =M.PO4= as the reference species!
 #+name: p4
 #+BEGIN_SRC ipython :tangle po4_1.py
 # boundary conditions
@@ -204,7 +204,7 @@ Reservoir(
 
 
 *** Model processes
-For many models, processes can mapped as the transfer of mass from one box to the next. Within the ESBMTK framework, this is accomplished through the @@rst::py:class:`esbmtk.connections.Species2Species()`@@ class. To connect the weathering flux from the source object (M.weathering) to the surface ocean (M.S_b) we declare a connection instance describing this relationship as follows:
+For many models, processes can mapped as the transfer of mass from one box to the next. Within the ESBMTK framework, this is accomplished through the @@rst::py:class:`esbmtk.connections.Species2Species()`@@ class or the @@rst::py:class:`esbmtk.connections.ConnectionProperties()`@@ class. To connect the weathering flux from the source object (M.weathering) to the surface ocean (M.S_b) we declare a connection instance describing this relationship as follows:
 #+name: p6
 #+BEGIN_SRC ipython :tangle po4_1.py
 ConnectionProperties(

--- a/docs/manual/manual-1.org
+++ b/docs/manual/manual-1.org
@@ -219,7 +219,7 @@ Unless the =register= keyword is given, connections will be automatically regist
 
 The connection type =ctype = "regular"= or =ctype = "fixed"= is used when connecting reservoirs with a fixed rate (eg: F_w = 45 Gmol/year, as defined above). However, we may also create a concentration-dependent flux connection. To map the process of thermohaline circulation, for example, we connect the surface and deep ocean boxes using a connection type that scales the mass transfer as a function of the concentration in a given reservoir (=ctype ="scale_with_concentration"= ). 
 
-The concentration data is taken from the reference reservoir, which by default is the source reservoir. As such, in most cases, the =ref_reservoirs= keyword can be omitted. The =scale= keyword can be a string or a numerical value. If it is provided as a string, ESBMTK will map the value into model units. Note that the connection class does not require the =name= keyword. Rather, the name is derived from the source and sink reservoir instances. Since reservoir instances can have more than one connection (i.e., surface to deep via downwelling, and surface to deep via primary production), it is required to set the =id= keyword.
+The concentration data is taken from the reference reservoir, which by default is the source reservoir. As such, in most cases, the =ref_reservoirs= keyword can be omitted. Note that the connection class does not require the =name= keyword. Rather, the name is derived from the source and sink reservoir instances. Since reservoir instances can have more than one connection (i.e., surface to deep via downwelling, and surface to deep via primary production), it is required to set the =id= keyword.
 
 #+name: p7
 #+BEGIN_SRC ipython :tangle po4_1.py
@@ -227,7 +227,8 @@ ConnectionProperties(  # thermohaline downwelling
     source=M.S_b,  # source of flux
     sink=M.D_b,  # target of flux
     ctype="scale_with_concentration",
-    scale=thc,
+    scale=thc, #(in sverdrups, i.e. volumetric rate) 
+    #volume / time * concentration (i.e. mass per unit volume) = flux (i.e. mass transfer per unit time)
     id="downwelling_PO4",
 )
 ConnectionProperties(  # thermohaline upwelling
@@ -238,6 +239,7 @@ ConnectionProperties(  # thermohaline upwelling
     id="upwelling_PO4",
 )
 #+END_SRC
+As seen above, the =scale= keyword can be a string or a numerical value. If it is provided as a string, ESBMTK will map the value into model units, i.e., the toolkit automatically handles unit conversions when scaling. For example, if concentration is described in mol/kg instead of mol/l, the above code for thermohaline circulation will automatically use the density of the relevant reservoirs to calculate the correct flux.
 
 There are several ways to define biological export production, e.g., as a function of the upwelling PO_4, or as a function of the residence time of PO_4 in the surface ocean. Here we follow Glover (2011) and use the residence time \tau = 100 years. Note that the below code species explicitly specifies the species that is affected by this process.
 
@@ -248,7 +250,7 @@ ConnectionProperties(  #
     sink=M.D_b,  # target of flux
     ctype="scale_with_concentration",
     scale=M.S_b.volume / tau, 
-    # volume / residence-time * concentration (i.e. mass per unit volume) = flux (i.e mass per unit time)
+    # volume / time * concentration (i.e. mass per unit volume) = flux (i.e mass transfer per unit time)
     id="primary_production",
     species=[M.PO4],  # apply this only to PO4
 )

--- a/docs/manual/manual-1.org
+++ b/docs/manual/manual-1.org
@@ -140,7 +140,7 @@ from esbmtk import (
 )
 #+END_SRC
 Next we use the @@rst::py:class:`esbmtk.model.Model()`@@  class to create a model instance that defines basic model properties. Note that units are automatically translated into model units. While convenient, there are some important caveats: 
-Internally, the model uses 'year' as the time unit, mol as the mass unit, and liter as the volume unit. You can change this by setting these values to e.g., 'mol' and 'kg', however, some functions assume that their input values are in 'mol/l' rather than mol/m**3 or 'kg/s'. Ideally, this would be caught by ESBMTK, but at present, this is not guaranteed. So your mileage may vary if you fiddle with these settings.  Note: Using mol/kg e.g., for seawater, will be discussed below.
+Internally, the model uses 'year' as the time unit, mol as the mass unit, and liter as the volume unit. You can change this by setting these values to e.g., 'mol' and 'kg', however, some functions assume that their input values are in 'mol/kg' rather than mol/m**3 or 'kg/s'. Ideally, this would be caught by ESBMTK, but at present, this is not guaranteed. So your mileage may vary if you fiddle with these settings.  Note: Using mol/kg e.g., for seawater, will be discussed below.
 #+name: p2
 #+BEGIN_SRC ipython :tangle po4_1.py
 # define the basic model parameters
@@ -204,7 +204,7 @@ Reservoir(
 
 
 *** Model processes
-For many models, processes can mapped as the transfer of mass from one box to the next. Within the ESBMTK framework, this is accomplished through the @@rst::py:class:`esbmtk.connections.Species2Species()`@@ class. To connect the weathering flux from the source object (M.w) to the surface ocean (M.S_b) we declare a connection instance describing this relationship as follows:
+For many models, processes can mapped as the transfer of mass from one box to the next. Within the ESBMTK framework, this is accomplished through the @@rst::py:class:`esbmtk.connections.Species2Species()`@@ class. To connect the weathering flux from the source object (M.weathering) to the surface ocean (M.S_b) we declare a connection instance describing this relationship as follows:
 #+name: p6
 #+BEGIN_SRC ipython :tangle po4_1.py
 ConnectionProperties(
@@ -212,12 +212,15 @@ ConnectionProperties(
     sink=M.S_b,  # target of flux
     rate=F_w,  # rate of flux
     id="river",  # connection id
-    ctype="regular",
+    ctype="regular", #connection type
 )
 #+END_SRC
 Unless the =register= keyword is given, connections will be automatically registered with the parent of the source, i.e., the model =M=. Unless explicitly given through the =name= keyword, connection names will be automatically constructed from the names of the source and sink instances. However, it is a good habit to provide the =id= keyword to keep connections separate in cases where two reservoir instances share more than one connection. The list of all connection instances can be obtained from the model object (see below).
 
-To map the process of thermohaline circulation, we connect the surface and deep ocean boxes using a connection type that scales the mass transfer as a function of the concentration in a given reservoir (=ctype ="scale_with_concentration"= ). The concentration data is taken from the reference reservoir which defaults to the source reservoir. As such, in most cases, the =ref_reservoirs= keyword can be omitted. The =scale= keyword can be a string or a numerical value. If it is provided as a string ESBMTK will map the value into model units. Note that the connection class does not require the =name= keyword. Rather the name is derived from the source and sink reservoir instances. Since reservoir instances can have more than one connection (i.e., surface to deep via downwelling, and surface to deep via primary production), it is required to set the =id= keyword.
+The connection type =ctype = "regular"= or =ctype = "fixed"= is used when connecting reservoirs with a fixed rate (eg: F_w = 45 Gmol/year, as defined above). However, we may also create a concentration-dependent flux connection. To map the process of thermohaline circulation, for example, we connect the surface and deep ocean boxes using a connection type that scales the mass transfer as a function of the concentration in a given reservoir (=ctype ="scale_with_concentration"= ). 
+
+The concentration data is taken from the reference reservoir, which by default is the source reservoir. As such, in most cases, the =ref_reservoirs= keyword can be omitted. The =scale= keyword can be a string or a numerical value. If it is provided as a string, ESBMTK will map the value into model units. Note that the connection class does not require the =name= keyword. Rather, the name is derived from the source and sink reservoir instances. Since reservoir instances can have more than one connection (i.e., surface to deep via downwelling, and surface to deep via primary production), it is required to set the =id= keyword.
+
 #+name: p7
 #+BEGIN_SRC ipython :tangle po4_1.py
 ConnectionProperties(  # thermohaline downwelling
@@ -237,19 +240,21 @@ ConnectionProperties(  # thermohaline upwelling
 #+END_SRC
 
 There are several ways to define biological export production, e.g., as a function of the upwelling PO_4, or as a function of the residence time of PO_4 in the surface ocean. Here we follow Glover (2011) and use the residence time \tau = 100 years. Note that the below code species explicitly specifies the species that is affected by this process.
+
 #+name: p8
 #+BEGIN_SRC ipython :tangle po4_1.py
 ConnectionProperties(  #
     source=M.S_b,  # source of flux
     sink=M.D_b,  # target of flux
     ctype="scale_with_concentration",
-    scale=M.S_b.volume / tau,
+    scale=M.S_b.volume / tau, 
+    # volume / residence-time * concentration (i.e. mass per unit volume) = flux (i.e mass per unit time)
     id="primary_production",
     species=[M.PO4],  # apply this only to PO4
 )
 #+END_SRC
 
-We require one more connection to describe the burial of P in the sediment. We describe this flux as a fraction of the primary export productivity. To create the connection we can either recalculate the export productivity or use the previously calculated flux. We can query the export productivity using the =id_string= of the above connection with the
+We require one more connection to describe the burial of P in the sediment. We describe this flux as a fraction of the primary export productivity. To create the connection we can either recalculate the export productivity or use the previously calculated flux via =ctype ="scale_with_flux"= and =ref_flux=. We can query the export productivity using the =id_string= of the above connection with the
 @@rst::py:meth:`esbmtk.model.Model.flux_summary()`@@ method of the model instance:
 #+BEGIN_SRC ipython
 M.flux_summary(filter_by="primary_production", return_list=True)[0]

--- a/docs/manual/manual-2.org
+++ b/docs/manual/manual-2.org
@@ -89,7 +89,7 @@ The original signal data (as read from a csv etc.) is available through the =.s_
 
 ** Working with multiple species
 The basic building blocks introduced so far are sufficient to create a single species model. Adding further species is straightforward. First one needs to import the species definitions. They than can be simply used by extending the dictionaries and lists used in the previous example.
-Using the previous example of a simple P-cycle model, we now express the P-cycling as a function of photosynthetic organic matter (OM) production and remineralization. First, we import the new classes and we additionally load the species definitions for carbon (this code is available as =po4_3.p4= see https://github.com/uliw/ESBMTK-Examples).
+Using the previous example of a simple P-cycle model, we now express the P-cycling as a function of photosynthetic organic matter (OM) production and remineralization. First, we import the new classes and we additionally load the species definitions for carbon (this code is available as =po4_3.py= see https://github.com/uliw/ESBMTK-Examples).
 #+name: po43_1
 #+BEGIN_SRC ipython :tangle po4_3.py
 from esbmtk import (
@@ -239,7 +239,9 @@ test_values = [ # result, reference value
 ** Using many boxes
 Using the ESBMTK classes introduced thus far is sufficient to build complex models. However, it is beneficial to leverage Python syntax to create utility functions that help reduce overly verbose code. The ESBMTK library includes several routines that aid in this process; however, they are not part of the core API, are not yet well documented, and have not undergone extensive testing. The following provides a brief introduction, but it may be useful to examine the code for the Boudreau 2010 model in the example directory, as it makes significant use of the Python dictionary class.
 
-For these functions to operate correctly, box names must adhere to the following template: =Area_depth=, such as =L_sb= for a low latitude surface water box or =D_db= for a deep water box. While the actual names are flexible, the underscore is utilized to distinguish between ocean area (i.e. low-latitude, high-latitude, etc.) and depth interval (i.e. surface, intermediate, deep, etc.). The following code examples demonstrate how to create multiple boxes simultaneously by first defining a dictionary containing the box geometry and initial values, followed by the @@rst::py:class:`esbmtk.utility_functions.initialize_reservoirs()`@@ function to instantiate the corresponding =Reservoir= objects. The =Boudreau2010.py= example available at https://github.com/uliw/ESBMTK-Examples illustrates a practical application of this approach.
+For these functions to operate correctly, box names must adhere to the following template: =Area_depth=, such as =L_sb= for a low latitude surface water box or =D_db= for a deep water box. While the actual names are flexible, the underscore is utilized to distinguish between ocean area (eg. low-latitude, high-latitude, etc.) and depth interval (eg. surface, intermediate, deep, etc.). 
+
+The following code examples demonstrate how to create multiple boxes simultaneously by first defining a dictionary containing the box geometry and initial values, followed by the @@rst::py:class:`esbmtk.utility_functions.initialize_reservoirs()`@@ function to instantiate the corresponding =Reservoir= objects. The =Boudreau2010.py= example available at https://github.com/uliw/ESBMTK-Examples illustrates a practical application of this approach.
 #+BEGIN_SRC ipython
 box_parameters: dict = {  # name: [[geometry], T, P]
     "H_b": {  # High-Lat Box
@@ -305,7 +307,7 @@ connection_dictionary = build_ct_dict(thx_dict, species_names)
 create_bulk_connections(connection_dictionary, M, mt="1:1")
 #+END_SRC
 
-In the following example, we build the =connection_dictionary= in a more explicit way to define primary production as a function of P upwelling: The first line finds all the upwelling fluxes, and we can then use them as an argument in the =connection_dictionary= definition:
+In the following example, we build the =connection_dictionary= in a more explicit way to define primary production as a function of P upwelling: the first line finds all the upwelling fluxes, and we can then use them as an argument in the =connection_dictionary= definition:
 #+BEGIN_SRC ipython
 # get all upwelling P fluxes except for the high latitude box
 pfluxes = M.flux_summary(filter_by="PO4_mix_up", exclude="H_", return_list=True)

--- a/docs/manual/manual-2.org
+++ b/docs/manual/manual-2.org
@@ -88,7 +88,7 @@ test_values = [ # result, reference value
 The original signal data (as read from a csv etc.) is available through the =.s_time=, =.s_data= instance variables. The padded/cropped data that is interpolated for each time point, is stored in the =.cd_m= (and =.cd_l= if isotope data is present) instance variables.The sub-sampled signal data that is used for plotting is stored in =.m=, =.l= and =.d= respectively.  Signal data can also be queried interactively by calling the signal with a given time values, e.g., =M.PO4_signal(12)=. 
 
 ** Working with multiple species
-The basic building blocks introduced so far, are sufficient to create a single species model. Adding further species, is straightforward. First one needs to import the species definitions. They than can be simply used by extending the dictionaries and lists used in the previous example.
+The basic building blocks introduced so far are sufficient to create a single species model. Adding further species is straightforward. First one needs to import the species definitions. They than can be simply used by extending the dictionaries and lists used in the previous example.
 Using the previous example of a simple P-cycle model, we now express the P-cycling as a function of photosynthetic organic matter (OM) production and remineralization. First, we import the new classes and we additionally load the species definitions for carbon (this code is available as =po4_3.p4= see https://github.com/uliw/ESBMTK-Examples).
 #+name: po43_1
 #+BEGIN_SRC ipython :tangle po4_3.py
@@ -129,7 +129,7 @@ Reservoir(
 )
 Reservoir(
     name="D_b",
-    volume="100E16 m**3",  # deeb box volume
+    volume="100E16 m**3",  # deep box volume
     concentration={M.DIC: "0 umol/l", M.PO4: "0 umol/l"},
 )
 #+END_SRC
@@ -151,7 +151,7 @@ ConnectionProperties(  # thermohaline upwelling
     id="thc_down",
 )
 #+END_SRC
-It is also possible, to specify individual rates or scales using a dictionary, as in this example that sets two different weathering fluxes:
+It is also possible to specify individual rates or scales using a dictionary, as in this example that sets two different weathering fluxes:
 #+name:po43_3
 #+BEGIN_SRC ipython :tangle po4_3.py
 ConnectionProperties(
@@ -237,9 +237,9 @@ test_values = [ # result, reference value
 #+END_SRC
 
 ** Using many boxes
-Using the ESBMTK classes introduced thus far is sufficient to build complex models. However, it is beneficial to leverage Python syntax to create utility functions that help reduce overly verbose code. The ESBMTK library includes several routines that aid in this process; however, they are not part of the core API, are not yet well documented, and have not undergone extensive testing. The following provides a brief introduction, but it may be useful to examine the code for the Boudreau 2010 and LOSCAR-type models in the example directory, as all of these make significant use of the Python dictionary class.
+Using the ESBMTK classes introduced thus far is sufficient to build complex models. However, it is beneficial to leverage Python syntax to create utility functions that help reduce overly verbose code. The ESBMTK library includes several routines that aid in this process; however, they are not part of the core API, are not yet well documented, and have not undergone extensive testing. The following provides a brief introduction, but it may be useful to examine the code for the Boudreau 2010 model in the example directory, as it makes significant use of the Python dictionary class.
 
-For these functions to operate correctly, box names must adhere to the following template: =Area_depth=, such as =L_sb= for a low latitude surface water box or =D_db= for a deep water box. While the actual names are flexible, the underscore is utilized to distinguish between ocean area and depth interval. The following code examples demonstrate how to create multiple boxes simultaneously by first defining a dictionary containing the box geometry and initial values, followed by the @@rst::py:class:`esbmtk.utility_functions.initialize_reservoirs()`@@ function to instantiate the corresponding =Reservoir= objects. The =Boudrea2010.py= example available at https://github.com/uliw/ESBMTK-Examples illustrates a practical application of this approach.
+For these functions to operate correctly, box names must adhere to the following template: =Area_depth=, such as =L_sb= for a low latitude surface water box or =D_db= for a deep water box. While the actual names are flexible, the underscore is utilized to distinguish between ocean area (i.e. low-latitude, high-latitude, etc.) and depth interval (i.e. surface, intermediate, deep, etc.). The following code examples demonstrate how to create multiple boxes simultaneously by first defining a dictionary containing the box geometry and initial values, followed by the @@rst::py:class:`esbmtk.utility_functions.initialize_reservoirs()`@@ function to instantiate the corresponding =Reservoir= objects. The =Boudreau2010.py= example available at https://github.com/uliw/ESBMTK-Examples illustrates a practical application of this approach.
 #+BEGIN_SRC ipython
 box_parameters: dict = {  # name: [[geometry], T, P]
     "H_b": {  # High-Lat Box
@@ -269,7 +269,10 @@ box_parameters: dict = {  # name: [[geometry], T, P]
 # Instantiate Reservoir objects        
 species_list = initialize_reservoirs(M, box_parameters)
 #+END_SRC
-Similarly, we can leverage  Python dictionaries to set up the transport matrix. The dictionary key must use the following template: =boxname_to_boxname@id= where the =id= is used similarly to the connection id in the =Species2Species= and =ConnectionProperties= classes. So to specify thermohaline upwelling from the Atlantic deep water to the Atlantic intermediate water you would use =A_db_to_A_ib@thc=  as the dictionary key, followed by the rate. The following examples define the thermohaline transport in a LOSCAR-type model:
+Similarly, we can leverage  Python dictionaries to set up the transport matrix. The dictionary key must use the following template: =boxname_to_boxname@id= where the =id= is used similarly to the connection id in the =Species2Species= and =ConnectionProperties= classes. 
+
+So to specify, for example, thermohaline upwelling from the Atlantic deep water to the Atlantic intermediate water, you would use =A_db_to_A_ib@thc=  as the dictionary key, followed by the rate. The following examples define the thermohaline transport in a LOSCAR-type model (based on https://gmd.copernicus.org/articles/5/149/2012/):
+
 #+BEGIN_SRC ipython
 # Conveyor belt
 thc = Q_("20*Sv")
@@ -302,18 +305,18 @@ connection_dictionary = build_ct_dict(thx_dict, species_names)
 create_bulk_connections(connection_dictionary, M, mt="1:1")
 #+END_SRC
 
-In the following example, we build the =connection_dictinary= in a more explicit way to define primary production as a function of P upwelling: The first line finds all the upwelling fluxes, and we can then use them as an argument in the =connection_dictionary= definition:
+In the following example, we build the =connection_dictionary= in a more explicit way to define primary production as a function of P upwelling: The first line finds all the upwelling fluxes, and we can then use them as an argument in the =connection_dictionary= definition:
 #+BEGIN_SRC ipython
 # get all upwelling P fluxes except for the high latitude box
 pfluxes = M.flux_summary(filter_by="PO4_mix_up", exclude="H_", return_list=True)
 
 # define export productivity in the high latitude box
-PO4_ex = Q_(f"{1.8 * M.H_sb.area/M.PC_ratio} mol/a")
+PO4_ex = Q_(f"{1.8 * M.H_sb.area/M.PC_ratio} mol/a") #PC ratio = Phosphorus:Carbon ratio
 
 c_dict = {  # Surface box to ib, about 78% is remineralized in the ib
     ("A_sb_to_A_ib@POM_P", "I_sb_to_I_ib@POM_P", "P_sb_to_P_ib@POM_P"): {
         "ty": "scale_with_flux",
-        "sc": M.PUE * M.ib_remin,
+        "sc": M.PUE * M.ib_remin, #PUE = Phosphorus Utilization Efficiency 
         "re": pfluxes,
         "sp": M.PO4,
     },  # surface box to deep box


### PR DESCRIPTION
- Fixed a number of typos and minor grammatical errors.
- Added more information about connection types and scaling in manual1 for enhanced clarity.
- Added clarifying comments and references to the LOSCAR-type model code example in manual2.