### PR TITLE
[Staging] Documentation Updates to Manual-4 and Manual-5

### DIFF
--- a/docs/manual/manual-4.org
+++ b/docs/manual/manual-4.org
@@ -163,6 +163,35 @@ M.D_b.zsnow  # Snowline depth in mbsl
 #+END_SRC
 see  the @@rst::py:func:`esbmtk.post_processing.carbonate_system_2_pp()`@@ function for details.
 
+** Carbonate System 3:
+
+*NOTE: this is currently in the early stages of development.*
+
+=carbonate_system_3= aims to extend the =carbonate_system_2= (CS2) code to be able to compute carbonate chemistry dynamics in models with more than two vertical ocean layers, for example, a model with a surface layer (0m to 100m), an intermediate layer (100m to 2000m), and a deep layer (2000m to 6000m). Like CS2, it is also based on the Boudreau (2010) model, but it aims to enable the partitioning of Boudreau's deep box into multiple vertical ocean layers. Its current capabilities are described below.
+
+As of July 2025, CS3 functions almost entirely similarly to CS2, except in that it explicitly computes the "burial flux" (i.e. the carbonate flux that remains undissolved in a given box) and adds it to the reservoir box directly beneath it. 
+
+Carbonate System 3 may be added to a model as follows:
+
+#+BEGIN_SRC ipython
+
+export_fluxes: tp.List = M.flux_summary(filter_by="PIC_DIC L_b", return_list=True)
+
+add_carbonate_system_3(
+        source_box=[M.S_b],  # list of reservoir groups; S_b is Surface box
+        this_box=[M.D_b1],  # list of reservoir groups; D_b1 is Deep box 1
+        next_box=[M.D_b2],  # list of reservoir groups; D_b2 is Deep box 2
+        carbonate_export_fluxes=export_fluxes,  # list of export fluxes
+        z0=-200,  # depth of shelf
+        alpha=alpha,  # dissolution coefficient, typically around 0.6
+    )
+f = M.flux_summary(filter_by="db2_export") #"db2_export" is the flux from D_b1 to D_b2 (i.e. "burial flux")
+M.D_b2.DIC.lif.append(f) #appends the db2_export flux object to the sink.lif list
+#+END_SRC
+
+Notes:
+- At the moment, =next_box= must be a Reservoir class object and cannot be a Sink class object. However, one can still use this setup to pass burial flux from an ocean box to a sediment box by defining the sediment box as a Reservoir class object with seawater parameters (T, P, S) exactly equal to the ocean box just above it, and initial DIC and TA set to 0.
+- As in CS2, the CS3 code adds carbonate export fluxes to =this_box=, but relies on a ConnectionProperties instance (with the bypass "bp" keyword) to remove those same fluxes from the source box. However, there is no need to use ConnectionProperties to set up a PIC flux connection between =this_box= and =next_box= at all, as this is handled entirely by the CS3 code. 
 
 ** Gas Exchange
 ESBMTK implements gas exchange across the Air-Sea interface as a @@rst::py:class:`esbmtk.connections.Species2Species()`@@ instance, between a @@rst::py:class:`esbmtk.extended_classes.GasReservoir()`@@ and a @@rst::py:class:`esbmtk.base_classes.Species()`@@ instance. In the following example, we first declare a =Gasreservoir= and then connect it with a regular surface box. Note that the CO_{2} gas transfer calculation requires that the respective surface reservoir carries the =CO2aq= tracer as calculated by the @@rst::py:func:`esbmtk.bio_pump_functions0.carbonate_chemistry_carbonate_system_1.()`@@ function since the gas-transfer depends on the dissolved CO_{2} rather than on the DIC concentration.

--- a/docs/manual/manual-4.org
+++ b/docs/manual/manual-4.org
@@ -136,8 +136,9 @@ Notes:
  - boxes and fluxes are lists, since in some models there is more than one surface box (e.g., models that resolve individual ocean basins)
  - ESBMTK only considers the sediment area to 6000 mbsl. The area contributed by the elevations below 6000 mbsl is negligible, and this constrain simplifies the hypsographic fit.
  - The total sediment area of a given =Reservoir= is known provided the box-geometry was specified correctly.
- - The @@rst::py:func:`esbmtk.bio_pump_functions0.carbonate_chemistry.carbonate_system_2()`@@ function only returns [H^{+}] and the dissolution flux for  given box. It does not return the burial flux.
- - Please study the actual model implementations provided in the examples folder.
+ - The @@rst::py:func:`esbmtk.bio_pump_functions0.carbonate_chemistry.carbonate_system_2()`@@ function only returns [H^{+}] and the dissolution flux for the given box. It does not return the burial flux.
+ - Since carbonate_system_2 is based heavily on the Boudreau model, it cannot currently handle carbonate chemistry dynamics for models with more than two vertical ocean boxes, eg: it cannot be used within a model with a surface, intermediate, as well as deep box. 
+Please study the actual model implementations provided in the examples folder.
 
 *** Post-Processing
 As with =carbonate_system_1= the remaining carbonate species are not part of the equation system, rather they are calculated once a solution has been found. Since the solver does not store the carbonate export fluxes, one first has to calculate the relevant fluxes from the concentration data in the model solution. This is however model dependent (i.e., export productivity as a function of residence time, or as a function of upwelling flux), and as such post-processing of =carbonate_system_2=  is not done automatically, but has to be initiated manually, e.g., like this:

--- a/docs/manual/manual-4.org
+++ b/docs/manual/manual-4.org
@@ -141,7 +141,7 @@ Notes:
 Please study the actual model implementations provided in the examples folder.
 
 *** Post-Processing
-As with =carbonate_system_1= the remaining carbonate species are not part of the equation system, rather they are calculated once a solution has been found. Since the solver does not store the carbonate export fluxes, one first has to calculate the relevant fluxes from the concentration data in the model solution. This is however model dependent (i.e., export productivity as a function of residence time, or as a function of upwelling flux), and as such post-processing of =carbonate_system_2=  is not done automatically, but has to be initiated manually, e.g., like this:
+As with =carbonate_system_1=, the remaining carbonate species are not part of the equation system, rather they are calculated once a solution has been found. Since the solver does not store the carbonate export fluxes, one first has to calculate the relevant fluxes from the concentration data in the model solution. This is however model dependent (i.e., export productivity as a function of residence time, or as a function of upwelling flux), and as such post-processing of =carbonate_system_2=  is not done automatically, but has to be initiated manually, e.g., like this:
 #+BEGIN_SRC ipython
 # get CaCO3_export in mol/year
 CaCO3_export = M.CaCO3_export.to(f"{M.f_unit}").magnitude
@@ -163,7 +163,7 @@ M.D_b.zsnow  # Snowline depth in mbsl
 #+END_SRC
 see  the @@rst::py:func:`esbmtk.post_processing.carbonate_system_2_pp()`@@ function for details.
 
-** Carbonate System 3:
+*** Carbonate System 3:
 
 *NOTE: this is currently in the early stages of development.*
 
@@ -175,13 +175,11 @@ Carbonate System 3 may be added to a model as follows:
 
 #+BEGIN_SRC ipython
 
-export_fluxes: tp.List = M.flux_summary(filter_by="PIC_DIC L_b", return_list=True)
-
 add_carbonate_system_3(
         source_box=[M.S_b],  # list of reservoir groups; S_b is Surface box
         this_box=[M.D_b1],  # list of reservoir groups; D_b1 is Deep box 1
         next_box=[M.D_b2],  # list of reservoir groups; D_b2 is Deep box 2
-        carbonate_export_fluxes=export_fluxes,  # list of export fluxes
+        carbonate_export_fluxes=export_fluxes,  # list of export fluxes; declared in the same way as in CS2
         z0=-200,  # depth of shelf
         alpha=alpha,  # dissolution coefficient, typically around 0.6
     )

--- a/docs/manual/manual-4.org
+++ b/docs/manual/manual-4.org
@@ -137,7 +137,7 @@ Notes:
  - ESBMTK only considers the sediment area to 6000 mbsl. The area contributed by the elevations below 6000 mbsl is negligible, and this constrain simplifies the hypsographic fit.
  - The total sediment area of a given =Reservoir= is known provided the box-geometry was specified correctly.
  - The @@rst::py:func:`esbmtk.bio_pump_functions0.carbonate_chemistry.carbonate_system_2()`@@ function only returns [H^{+}] and the dissolution flux for the given box. It does not return the burial flux.
- - Since carbonate_system_2 is based heavily on the Boudreau model, it cannot currently handle carbonate chemistry dynamics for models with more than two vertical ocean boxes, eg: it cannot be used within a model with a surface, intermediate, as well as deep box. 
+ - Since =carbonate_system_2= is based heavily on the Boudreau model, it cannot currently handle carbonate chemistry dynamics for models with more than two vertical ocean boxes, eg: it cannot be used within a model with a surface, intermediate, as well as deep box. 
 Please study the actual model implementations provided in the examples folder.
 
 *** Post-Processing
@@ -190,6 +190,9 @@ M.D_b2.DIC.lif.append(f) #appends the db2_export flux object to the sink.lif lis
 Notes:
 - At the moment, =next_box= must be a Reservoir class object and cannot be a Sink class object. However, one can still use this setup to pass burial flux from an ocean box to a sediment box by defining the sediment box as a Reservoir class object with seawater parameters (T, P, S) exactly equal to the ocean box just above it, and initial DIC and TA set to 0.
 - As in CS2, the CS3 code adds carbonate export fluxes to =this_box=, but relies on a ConnectionProperties instance (with the bypass "bp" keyword) to remove those same fluxes from the source box. However, there is no need to use ConnectionProperties to set up a PIC flux connection between =this_box= and =next_box= at all, as this is handled entirely by the CS3 code. 
+
+**** Post Processing
+CS3 post-processing currently (As of July 2025) functions in the same manner as CS2 post-processing. The sole difference is the name of the function, which for CS3 is =carbonate_system_3_pp=.
 
 ** Gas Exchange
 ESBMTK implements gas exchange across the Air-Sea interface as a @@rst::py:class:`esbmtk.connections.Species2Species()`@@ instance, between a @@rst::py:class:`esbmtk.extended_classes.GasReservoir()`@@ and a @@rst::py:class:`esbmtk.base_classes.Species()`@@ instance. In the following example, we first declare a =Gasreservoir= and then connect it with a regular surface box. Note that the CO_{2} gas transfer calculation requires that the respective surface reservoir carries the =CO2aq= tracer as calculated by the @@rst::py:func:`esbmtk.bio_pump_functions0.carbonate_chemistry_carbonate_system_1.()`@@ function since the gas-transfer depends on the dissolved CO_{2} rather than on the DIC concentration.

--- a/docs/manual/manual-5.org
+++ b/docs/manual/manual-5.org
@@ -229,7 +229,11 @@ The file =user_defined_functions.py= in the =examples= directory shows a working
 
 ** Debugging custom function integration 
 
-The current custom function integration interface is not very user-friendly and often requires investigating the actual =equations.py= file. In the default operating mode, ESBMTK will recreate this file for each model run, so that print statements and breakpoints that have been placed in =equations.py= have no effect.
+The current custom function integration interface is not very user-friendly and often requires investigating the actual =equations.py= file. The equations file is generated via setting ~M.debug_equations_file=True~ before running the model. 
+
+The flux connections for any particular reservoir box and associated species (eg: M.box_name.species) may also be inspected by calling ~[print(f.full_name) for f in M.box_name.species.lof]~ in the python console after the model run is finished. This will show all flux connections that are registered with the reservoir, and if the custom function has been successfully registered, this should include the fluxes created by the custom function.
+
+One can also add print statements into the equations.py file in order to obtain the flux values for any specific flux for each time-step. In the default operating mode, ESBMTK will recreate the equations.py file for each model run, so that print statements and breakpoints that have been placed in =equations.py= have no effect.
 Use the =parse_model= keyword in the model instance to keep the edited =equations.py= for the next run:
 #+BEGIN_SRC ipython
 M = Model(

--- a/docs/manual/manual-5.org
+++ b/docs/manual/manual-5.org
@@ -164,6 +164,8 @@ register_user_function(M, "my_functions", "my_burial")
 #+END_SRC
 Note that the last argument can also be a list of function names.
 
+The same may also be done by modifying the ~__init__.py~ file in the locally-hosted ESBMTK source code, and using the standard python syntax of ~from file_name.py import function_name as function_alias~.
+
 Next, we need to create code that maps the model variables required by =my_burial()= to the actual function call. Most of this work is done by the @@rst::py:class:`esbmtk.extended_classes.ExternalCode()`@@ class. In the following example, we wrap this task into a dedicated function, but this is not a hard requirement. I add this function to the =my_functions.py= file, but you can also keep it with the code that defines the model.  Since we want to use this function to calculate a flux between two reservoirs (or a sink/source), we need to pass the source and sink reservoirs, as well as the species and the scale information, to =add_my_burial()=.
 
 Notes on the below code:
@@ -224,6 +226,8 @@ add_my_burial(
 )
 #+END_SRC
 Note that  =M.D_b.volume.magnitude= is not a number but a quantity. So one needs to query the numerical value with =.magnitude=  or add code to  =add_my_burial= to query the type of the input arguments and convert as necessary.
+
+Also note that if introducing new keywords that are not already defined within the relevant ESBMTK class, it may be necessary to modify =ExtendedClasses.py= in the locally-hosted ESBMTK source code. 
 
 The file =user_defined_functions.py= in the =examples= directory shows a working example. 
 


### PR DESCRIPTION
This pull request concerns documentation updates only. 

Manual-4.org:
- added a caveat about CS2's inability to function for models with 2+ vertical ocean layers
- added a section about carbonate_system_3 (including aim, current status, and key notes)
- added a section about carbonate_system_3_pp (post-processing)

Manual-5.org:
- Made a note about the occasional need for modifying __ init__.py and extended_classes.py in the locally-hosted source code when adding custom functions.
- Elaborated on ESBMTK custom function debug methods for added clarity and accessibility.